### PR TITLE
BAH-2436 | Use amazoncorretto as base image

### DIFF
--- a/.github/workflows/deploy-publish.yaml
+++ b/.github/workflows/deploy-publish.yaml
@@ -5,7 +5,7 @@ on:
       - main
       - 'release-*'
       - BAH-1938
-      
+
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
     paths-ignore:
@@ -25,9 +25,9 @@ jobs:
           ./setArtifactVersion.sh
           rm setArtifactVersion.sh
       - name: Setup Java 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: "zulu"
+          distribution: "corretto"
           java-version: "8"
       - name: Run Unit Tests
         run: mvn --no-transfer-progress clean test

--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-alpine
+FROM amazoncorretto:8
 ENV SERVER_PORT=8080
 ENV BASE_DIR=/var/run/crater-atomfeed
 ENV CONTEXT_PATH=/crater-atomfeed
@@ -7,7 +7,7 @@ ENV SERVER_OPTS="-Xms512m -Xmx1024m -XX:PermSize=256m -XX:MaxPermSize=512m"
 ENV DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,address=8002,server=y,suspend=n"
 
 # Used by envsubst command for replacing environment values at runtime
-RUN apk add gettext curl
+RUN yum install -y gettext nc
 ADD https://repo.mybahmni.org/packages/build/bahmni-embedded-tomcat-8.0.42.jar /opt/crater-atomfeed/lib/crater-atomfeed.jar
 COPY feed-integration-webapp/target/crater-atomfeed.war /etc/crater-atomfeed/crater-atomfeed.war
 RUN mkdir -p ${WAR_DIRECTORY}
@@ -18,6 +18,6 @@ COPY package/docker/templates/application.properties.template /opt/crater-atomfe
 COPY package/docker/templates/crater.properties.template /opt/crater-atomfeed/etc/crater.properties.template
 RUN curl -o wait-for.sh 'https://raw.githubusercontent.com/eficode/wait-for/v2.2.3/wait-for'
 COPY package/docker/scripts/start.sh start.sh
-RUN chmod +x start.sh 
+RUN chmod +x start.sh
 RUN chmod +x wait-for.sh
 CMD [ "./start.sh" ]


### PR DESCRIPTION
Using amazoncorreto as baseimage since openjdk builds has beeen deprecated. More info [here](https://talk.openmrs.org/t/using-amazoncorretto-as-base-image-for-bahmni-docker-images/37668).

Co-authored-by: Divij Goyal [divij.g@beehyv.com](mailto:divij.g@beehyv.com)