### PR TITLE
[Rahul] | BAH-3005 | Add. Timezone Global Value For Helm Charts

### DIFF
--- a/package/helm/templates/configMap.yaml
+++ b/package/helm/templates/configMap.yaml
@@ -9,4 +9,5 @@ data:
   CRATER_URL:  "{{ .Values.config.CRATER_URL }}"
   OPENMRS_HOST: "{{ .Values.config.OPENMRS_HOST }}"
   OPENMRS_PORT: "{{ .Values.config.OPENMRS_PORT }}"
+  TZ: "{{ .Values.global.TZ }}"
   

--- a/package/helm/values.yaml
+++ b/package/helm/values.yaml
@@ -3,6 +3,7 @@ global:
   affinity: {}
   tolerations: {}
   storageClass: ""
+  TZ: "UTC"
 
 ReplicaCount: 1
 


### PR DESCRIPTION
Jira Card -> https://bahmni.atlassian.net/browse/BAH-3005

In this PR, we have added the TZ environment variable to the helm charts to configure the timezone for the [crater-atomfeed](https://github.com/Bahmni/crater-atomfeed) container.